### PR TITLE
emits the complete event when starting and backlog is empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ module.exports = function (input, jobs, map, work) {
         //hardcoded timeout WTF
         }, 50)
       }
-      
+
       jobs.del(data.key, function (err) {
         if(err) return retry.push(data)
 
@@ -100,9 +100,14 @@ module.exports = function (input, jobs, map, work) {
 
   //process the whole db as a batch
   jobs.start = function () {
+    var hadData = false;
     input.createReadStream({valueEncoding: 'utf8'})
       .on('data', function (data) {
+        hadData = true
         doHook(data, doJob)
+      })
+      .on('end', function () {
+        if (! hadData && ! working) jobs.emit('complete')
       })
     return jobs
   }


### PR DESCRIPTION
When starting up and the pending jobs db is empty, trigDb should also emit the "complete" event so that we know we're done with the backlog.
