### PR TITLE
deleting the running state in case of error

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ module.exports = function (input, jobs, map, work) {
       done = true
       if(err) {
         return setTimeout(function () {
+          delete running[hash]
           doJob(data)
         //hardcoded timeout WTF
         }, 50)


### PR DESCRIPTION
When the done callback is called with an error, the work is retried in 50ms, but the retry fails because `running[hash]` exists. Resetting that state enables the job to be run again.
