### PR TITLE
not repeating job after the job is done

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,6 @@ module.exports = function (input, jobs, map, work) {
         if(pending[hash]) {
           pendingCount --
           delete pending[hash]
-          doJob(data)
         }
 
         checkComplete()


### PR DESCRIPTION
This fixes a job repetition I detected in my app.
When the job is complete and was pending, there is no need to call `doJob`.
