### PR TITLE
hook doesn't continue if operation was a del

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,8 @@ module.exports = function (input, jobs, map, work) {
 
   function doHook (ch, add) {
     var key = map(ch)
-    if(key == null) return
+    if(key == null || ! ch.value) return
+
     var hash = shasum(key)
 
     if(!running[hash])

--- a/test/index.js
+++ b/test/index.js
@@ -18,13 +18,13 @@ var trigDb = Trigger(db, 'test-trigger', function (item) {
     }))
     var obj = item.value ? JSON.parse(item.value) : null
     return JSON.stringify({
-      key: ''+item.key, 
+      key: ''+item.key,
       type: item.type
     })
   },
   function (value, done) {
     value = JSON.parse(value)
-    
+
     function reduce (acc, n, put) {
       return (acc || 0) + (put ? 1 : -1)
     }
@@ -59,7 +59,7 @@ var i = setInterval(function () {
     clearInterval(i)
 }, 20)
 
-db.on('test:reduce', mac().times(5))
+db.on('test:reduce', mac().times(4))
 
 process.on('exit', function () {
   assert.equal(_done, true)


### PR DESCRIPTION
I now know why I'm getting repeated work on my app: it's because I'm deleting the record before calling done.
The  `doHook` function didn't check whether the operation was a del or a put, marking the job as pending.
The `doJob` was still running again and not triggering [this guard](https://github.com/dominictarr/level-trigger/blob/00e28039ac25c61501f09da7c1098edd3efd3c61/index.js#L42) because the repeated data still contained the previous `put` change.

Still, I'm not 100% sure about this change: Was there a reason why you wanted to repeat doJob if the job was deleted before it was complete?
